### PR TITLE
1. fixed crash while using Dropdown in android

### DIFF
--- a/InputKit.nuspec
+++ b/InputKit.nuspec
@@ -161,14 +161,14 @@
     <file src="InputKit\bin\Release\netstandard2.0\Plugin.InputKit.dll" target="lib\netstandard2.0\Plugin.InputKit.dll" />
     <file src="InputKit\bin\Release\netstandard2.0\Plugin.InputKit.xml" target="lib\netstandard2.0\Plugin.InputKit.xml" />
 
-    <file src="InputKit\bin\Release\monoandroid80\Plugin.InputKit.dll" target="lib\monoandroid80\Plugin.InputKit.dll" />
-    <file src="InputKit\bin\Release\monoandroid80\Plugin.InputKit.xml" target="lib\monoandroid80\Plugin.InputKit.xml" />
+    <file src="InputKit\bin\Release\monoandroid80\Plugin.InputKit.dll" target="lib\monoandroid81\Plugin.InputKit.dll" />
+    <file src="InputKit\bin\Release\monoandroid80\Plugin.InputKit.xml" target="lib\monoandroid81\Plugin.InputKit.xml" />
 
     <file src="InputKit\bin\Release\xamarin.ios10\Plugin.InputKit.dll" target="lib\xamarin.ios10\Plugin.InputKit.dll" />
     <file src="InputKit\bin\Release\xamarin.ios10\Plugin.InputKit.xml" target="lib\xamarin.ios10\Plugin.InputKit.xml" />
 
-    <file src="InputKit\bin\Release\xamarin.mac20\Plugin.InputKit.dll" target="lib\xamarin.mac20\Plugin.InputKit.dll" />
-    <file src="InputKit\bin\Release\xamarin.mac20\Plugin.InputKit.xml" target="lib\xamarin.mac20\Plugin.InputKit.xml" />
+    <!-- <file src="InputKit\bin\Release\xamarin.mac20\Plugin.InputKit.dll" target="lib\xamarin.mac20\Plugin.InputKit.dll" />
+    <file src="InputKit\bin\Release\xamarin.mac20\Plugin.InputKit.xml" target="lib\xamarin.mac20\Plugin.InputKit.xml" /> -->
 
     <file src="InputKit\bin\Release\xamarin.tvos10\Plugin.InputKit.dll" target="lib\xamarin.tvos10\Plugin.InputKit.dll" />
     <file src="InputKit\bin\Release\xamarin.tvos10\Plugin.InputKit.xml" target="lib\xamarin.tvos10\Plugin.InputKit.xml" />

--- a/InputKit/InputKit.csproj
+++ b/InputKit/InputKit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;MonoAndroid80;Xamarin.iOS10;Xamarin.TVOS10;Xamarin.WatchOS10;Xamarin.Mac20;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;MonoAndroid81;Xamarin.iOS10;Xamarin.TVOS10;Xamarin.WatchOS10;Xamarin.Mac20;</TargetFrameworks>
     <!--<TargetFrameworks>netstandard2.0;MonoAndroid80;Xamarin.iOS10;</TargetFrameworks>-->
     <AssemblyName>Plugin.InputKit</AssemblyName>
     <RootNamespace>Plugin.InputKit</RootNamespace>
@@ -59,7 +59,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid81' ">
     <Compile Include="Platforms\Droid\**\*.cs" />
     <PackageReference Include="Plugin.CurrentActivity" Version="2.1.0.4" PrivateAssets="All" />
 

--- a/InputKit/Platforms/Droid/MenuEffect.cs
+++ b/InputKit/Platforms/Droid/MenuEffect.cs
@@ -1,4 +1,6 @@
-﻿using Android.Widget;
+﻿using Android.Content;
+using Android.OS;
+using Android.Support.V7.Widget;
 using Plugin.InputKit.Platforms.Droid;
 using System.Linq;
 using Xamarin.Forms;
@@ -19,20 +21,17 @@ namespace Plugin.InputKit.Platforms.Droid
 
             if (Effect != null)
                 Effect.Parent.OnPopupRequest += OnPopupRequest;
-
+            Context context = Plugin.CurrentActivity.CrossCurrentActivity.Current.AppContext;
             if (Control != null)
             {
-                ToggleMenu = new PopupMenu(Plugin.CurrentActivity.CrossCurrentActivity.Current.AppContext, Control);
-                ToggleMenu.Gravity = Android.Views.GravityFlags.Right;
-                ToggleMenu.MenuItemClick += MenuItemClick;
+                ToggleMenu = new PopupMenu(context, Control);
             }
-
             else if (Container != null)
             {
-                ToggleMenu = new PopupMenu(Plugin.CurrentActivity.CrossCurrentActivity.Current.AppContext, Container);
-                ToggleMenu.Gravity = Android.Views.GravityFlags.Right;
-                ToggleMenu.MenuItemClick += MenuItemClick;
+                ToggleMenu = new PopupMenu(context, Container);
             }
+            ToggleMenu.Gravity = (int)Android.Views.GravityFlags.Right;
+            ToggleMenu.MenuItemClick += MenuItemClick;
         }
 
         void OnPopupRequest(View view)

--- a/Sample.InputKit/Sample.InputKit.Android/Properties/AndroidManifest.xml
+++ b/Sample.InputKit/Sample.InputKit.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.Sample.InputKit">
-	<uses-sdk android:minSdkVersion="15" />
+	<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="27" />
 	<application android:label="Sample.InputKit.Android"></application>
 </manifest>

--- a/Sample.InputKit/Sample.InputKit.Android/Sample.InputKit.Android.csproj
+++ b/Sample.InputKit/Sample.InputKit.Android/Sample.InputKit.Android.csproj
@@ -15,7 +15,6 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
@@ -28,6 +27,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
+    <AotAssemblies>false</AotAssemblies>
+    <EnableLLVM>false</EnableLLVM>
+    <BundleAssemblies>false</BundleAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -38,6 +40,9 @@
     <WarningLevel>4</WarningLevel>
     <AndroidManagedSymbols>true</AndroidManagedSymbols>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+    <AotAssemblies>false</AotAssemblies>
+    <EnableLLVM>false</EnableLLVM>
+    <BundleAssemblies>false</BundleAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />
@@ -84,7 +89,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\InputKit\InputKit.csproj">
-      <Project>{B7F4F0DD-F749-4E39-9353-81B6BB56DFC8}</Project>
+      <Project>{b7f4f0dd-f749-4e39-9353-81b6bb56dfc8}</Project>
       <Name>InputKit</Name>
     </ProjectReference>
     <ProjectReference Include="..\Sample.InputKit\Sample.InputKit.csproj">


### PR DESCRIPTION
1. change monoandroid80 to monoandroid81
2. fixed crash while using Dropdown in android if version is lower than 6.0
[issue7](https://github.com/enisn/Xamarin.Forms.InputKit/issues/34)