### PR TITLE
[New Feature]Add labelposition to radiobutton and checkbox

### DIFF
--- a/InputKit/InputKit.csproj
+++ b/InputKit/InputKit.csproj
@@ -150,4 +150,7 @@
 
   <Import Project="inputkit.targets" Condition="Exists('inputkit.targets')" />
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
+  <ItemGroup>
+    <None Remove="Shared\LabelPosition.cs" />
+  </ItemGroup>
 </Project>

--- a/InputKit/Shared/Configuration/GlobalSetting.cs
+++ b/InputKit/Shared/Configuration/GlobalSetting.cs
@@ -52,6 +52,10 @@ namespace Plugin.InputKit.Shared.Configuration
         /// Font family of control.
         /// </summary>
         public string FontFamily { get; set; }
+        /// <summary>
+        /// Label position of control.
+        /// </summary>
+        public LabelPosition LabelPosition { get; set; }
 
         ///------------------------------------------------------------------
         /// <summary>

--- a/InputKit/Shared/Controls/CheckBox.cs
+++ b/InputKit/Shared/Controls/CheckBox.cs
@@ -22,6 +22,7 @@ namespace Plugin.InputKit.Shared.Controls
             Size = 25,
             CornerRadius = 4,
             FontSize = 14,
+            LabelPosition = LabelPosition.Before
         };
 
         #region Constants
@@ -50,8 +51,11 @@ namespace Plugin.InputKit.Shared.Controls
             this.Padding = new Thickness(0, 10);
             this.Spacing = 10;
             this.frmBackground.Content = boxSelected;
-            this.Children.Add(frmBackground);
-            this.Children.Add(lblOption);
+            //this.Children.Add(frmBackground);
+            //this.Children.Add(lblOption);
+
+            ApplyLabelPosition(LabelPosition);
+
             this.ApplyIsCheckedAction = ApplyIsChecked;
             this.ApplyIsPressedAction = ApplyIsPressed;
             this.GestureRecognizers.Add(new TapGestureRecognizer
@@ -181,6 +185,11 @@ namespace Plugin.InputKit.Shared.Controls
         /// Corner radius of Box of CheckBox.
         /// </summary>
         public float CornerRadius { get => (float)GetValue(CornerRadiusProperty); set => SetValue(CornerRadiusProperty, value); }
+        public LabelPosition LabelPosition
+        {
+            get => (LabelPosition)GetValue(LabelPositionProperty);
+            set => SetValue(LabelPositionProperty, value);
+        }
         #endregion
 
         #region BindableProperties
@@ -199,10 +208,32 @@ namespace Plugin.InputKit.Shared.Controls
         public static readonly BindableProperty CustomIconProperty = BindableProperty.Create(nameof(CustomIcon), typeof(ImageSource), typeof(CheckBox), default(ImageSource), propertyChanged: (bo, ov, nv) => (bo as CheckBox).UpdateType((bo as CheckBox).Type));
         public static readonly BindableProperty IsPressedProperty = BindableProperty.Create(nameof(IsPressed), typeof(bool), typeof(CheckBox), propertyChanged: (bo, ov, nv) => (bo as CheckBox).ApplyIsPressedAction((bo as CheckBox), (bool)nv));
         public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(nameof(CornerRadius), typeof(float), typeof(CheckBox), GlobalSetting.CornerRadius, propertyChanged: (bo, ov, nv) => (bo as CheckBox).frmBackground.CornerRadius = (float)nv);
+        public static readonly BindableProperty LabelPositionProperty = BindableProperty.Create(
+            propertyName: nameof(LabelPosition), declaringType: typeof(CheckBox),
+            returnType: typeof(LabelPosition), defaultBindingMode: BindingMode.TwoWay,
+            defaultValue: GlobalSetting.LabelPosition,
+            propertyChanged: (bo, ov, nv) => (bo as CheckBox).ApplyLabelPosition((LabelPosition)nv));
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
         #endregion
 
         #region Methods
+        private void ApplyLabelPosition(LabelPosition position)
+        {
+            Children.Clear();
+            if (position == LabelPosition.After)
+            {
+                lblOption.HorizontalOptions = LayoutOptions.Start;
+                Children.Add(frmBackground);
+                Children.Add(lblOption);
+            }
+            else
+            {
+                lblOption.HorizontalOptions = LayoutOptions.StartAndExpand;
+                Children.Add(lblOption);
+                Children.Add(frmBackground);
+            }
+        }
+
         void ExecuteCommand()
         {
             if (CheckChangedCommand?.CanExecute(CommandParameter ?? this) ?? false)

--- a/InputKit/Shared/Controls/CheckBox.cs
+++ b/InputKit/Shared/Controls/CheckBox.cs
@@ -183,6 +183,9 @@ namespace Plugin.InputKit.Shared.Controls
         /// Corner radius of Box of CheckBox.
         /// </summary>
         public float CornerRadius { get => (float)GetValue(CornerRadiusProperty); set => SetValue(CornerRadiusProperty, value); }
+        /// <summary>
+        /// Gets or sets the label position.
+        /// </summary>
         public LabelPosition LabelPosition
         {
             get => (LabelPosition)GetValue(LabelPositionProperty);

--- a/InputKit/Shared/Controls/CheckBox.cs
+++ b/InputKit/Shared/Controls/CheckBox.cs
@@ -22,7 +22,7 @@ namespace Plugin.InputKit.Shared.Controls
             Size = 25,
             CornerRadius = 4,
             FontSize = 14,
-            LabelPosition = LabelPosition.Before
+            LabelPosition = LabelPosition.After
         };
 
         #region Constants

--- a/InputKit/Shared/Controls/CheckBox.cs
+++ b/InputKit/Shared/Controls/CheckBox.cs
@@ -51,8 +51,6 @@ namespace Plugin.InputKit.Shared.Controls
             this.Padding = new Thickness(0, 10);
             this.Spacing = 10;
             this.frmBackground.Content = boxSelected;
-            //this.Children.Add(frmBackground);
-            //this.Children.Add(lblOption);
 
             ApplyLabelPosition(LabelPosition);
 

--- a/InputKit/Shared/Controls/RadioButton.cs
+++ b/InputKit/Shared/Controls/RadioButton.cs
@@ -205,6 +205,9 @@ namespace Plugin.InputKit.Shared.Controls
         [Browsable(false)]
 #endif
         public bool IsPressed { get => (bool)GetValue(IsPressedProperty); set => SetValue(IsPressedProperty, value); }
+        /// <summary>
+        /// Gets or sets the label position.
+        /// </summary>
         public LabelPosition LabelPosition
         {
             get => (LabelPosition)GetValue(LabelPositionProperty);
@@ -260,7 +263,7 @@ namespace Plugin.InputKit.Shared.Controls
         void Tapped()
         {
             if (IsDisabled) return;
-            IsChecked = !IsChecked;
+            IsChecked = true;
             Clicked?.Invoke(this, new EventArgs());
             ClickCommand?.Execute(CommandParameter ?? Value);
 

--- a/InputKit/Shared/Controls/RadioButton.cs
+++ b/InputKit/Shared/Controls/RadioButton.cs
@@ -1,6 +1,7 @@
 ﻿using Plugin.InputKit.Shared.Abstraction;
 using Plugin.InputKit.Shared.Configuration;
 using Plugin.InputKit.Shared.Layouts;
+using Plugin.InputKit.Shared;
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -29,6 +30,7 @@ namespace Plugin.InputKit.Shared.Controls
             Size = Device.GetNamedSize(Device.RuntimePlatform == Device.iOS ? NamedSize.Large : NamedSize.Medium, typeof(Label)) * 1.2,
             CornerRadius = -1,
             FontSize = Device.GetNamedSize(Device.RuntimePlatform == Device.iOS ? NamedSize.Medium : NamedSize.Small, typeof(Label)),
+            LabelPosition = LabelPosition.Before
         };
         #endregion
 
@@ -38,9 +40,10 @@ namespace Plugin.InputKit.Shared.Controls
         #endregion
 
         #region Fields
+        internal Grid IconLayout;
         internal IconView iconCircle = new IconView { Source = ImageSource.FromResource(RESOURCE_CIRCLE), FillColor = GlobalSetting.BorderColor, VerticalOptions = LayoutOptions.CenterAndExpand, HorizontalOptions = LayoutOptions.Center, HeightRequest = GlobalSetting.Size, WidthRequest = GlobalSetting.Size };
         internal IconView iconChecked = new IconView { Source = ImageSource.FromResource(RESOURCE_DOT), FillColor = GlobalSetting.Color, IsVisible = false, VerticalOptions = LayoutOptions.CenterAndExpand, HorizontalOptions = LayoutOptions.Center, HeightRequest = GlobalSetting.Size, WidthRequest = GlobalSetting.Size };
-        internal Label lblText = new Label { IsVisible = false ,VerticalTextAlignment = TextAlignment.Center, VerticalOptions = LayoutOptions.CenterAndExpand, TextColor = GlobalSetting.TextColor, FontSize = GlobalSetting.FontSize, FontFamily = GlobalSetting.FontFamily };
+        internal Label lblText = new Label { IsVisible = false, VerticalTextAlignment = TextAlignment.Center, VerticalOptions = LayoutOptions.CenterAndExpand, TextColor = GlobalSetting.TextColor, FontSize = GlobalSetting.FontSize, FontFamily = GlobalSetting.FontFamily };
         private bool _isDisabled;
         #endregion
 
@@ -56,8 +59,10 @@ namespace Plugin.InputKit.Shared.Controls
             this.ApplyIsPressedAction = ApplyIsPressed;
             if (Device.RuntimePlatform != Device.iOS)
                 lblText.FontSize = lblText.FontSize *= 1.5;
+
             Orientation = StackOrientation.Horizontal;
-            this.Children.Add(new Grid
+
+            IconLayout = new Grid
             {
                 VerticalOptions = LayoutOptions.CenterAndExpand,
                 Children =
@@ -66,8 +71,9 @@ namespace Plugin.InputKit.Shared.Controls
                     iconChecked
                 },
                 MinimumWidthRequest = GlobalSetting.Size * 1.66,
-            });
-            this.Children.Add(lblText);
+            };
+            ApplyLabelPosition(LabelPosition);
+
             this.GestureRecognizers.Add(new TapGestureRecognizer { Command = new Command(Tapped) });
         }
         ///-----------------------------------------------------------------------------
@@ -199,12 +205,17 @@ namespace Plugin.InputKit.Shared.Controls
         [Browsable(false)]
 #endif
         public bool IsPressed { get => (bool)GetValue(IsPressedProperty); set => SetValue(IsPressedProperty, value); }
+        public LabelPosition LabelPosition
+        {
+            get => (LabelPosition)GetValue(LabelPositionProperty);
+            set => SetValue(LabelPositionProperty, value);
+        }
         #endregion
 
         #region BindableProperties
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public static readonly BindableProperty IsCheckedProperty = BindableProperty.Create(nameof(IsChecked), typeof(bool), typeof(RadioButton), false, propertyChanged: (bo, ov, nv) => (bo as RadioButton).ApplyIsCheckedAction((bool)nv));
-        public static readonly BindableProperty IsDisabledProperty = BindableProperty.Create(nameof(IsDisabled), typeof(bool), typeof(RadioButton), false, propertyChanged: (bo, ov, nv) => (bo as RadioButton).IsDisabled = (bool) nv);
+        public static readonly BindableProperty IsDisabledProperty = BindableProperty.Create(nameof(IsDisabled), typeof(bool), typeof(RadioButton), false, propertyChanged: (bo, ov, nv) => (bo as RadioButton).IsDisabled = (bool)nv);
         public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(RadioButton), "", propertyChanged: (bo, ov, nv) => (bo as RadioButton).Text = (string)nv);
         public static readonly BindableProperty TextFontSizeProperty = BindableProperty.Create(nameof(TextFontSize), typeof(double), typeof(RadioButton), 20.0, propertyChanged: (bo, ov, nv) => (bo as RadioButton).TextFontSize = (double)nv);
         public static readonly BindableProperty ColorProperty = BindableProperty.Create(nameof(Color), typeof(Color), typeof(RadioButton), GlobalSetting.Color, propertyChanged: (bo, ov, nv) => (bo as RadioButton).UpdateColors());
@@ -216,11 +227,32 @@ namespace Plugin.InputKit.Shared.Controls
         public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(RadioButton), propertyChanged: (bo, ov, nv) => (bo as RadioButton).CommandParameter = nv);
         public static readonly BindableProperty IsPressedProperty = BindableProperty.Create(nameof(IsPressed), typeof(bool), typeof(RadioButton), propertyChanged: (bo, ov, nv) => (bo as RadioButton).ApplyIsPressedAction((bool)nv));
         public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create(nameof(FontFamily), typeof(string), typeof(RadioButton), propertyChanged: (bo, ov, nv) => (bo as RadioButton).FontFamily = (string)nv);
-        public static readonly BindableProperty CircleSizeProperty = BindableProperty.Create(nameof(CircleSize), typeof(double), typeof(RadioButton), 12d, propertyChanged: (bo, ov, nv) => (bo as RadioButton).SetCircleSize((double) nv));
+        public static readonly BindableProperty CircleSizeProperty = BindableProperty.Create(nameof(CircleSize), typeof(double), typeof(RadioButton), 12d, propertyChanged: (bo, ov, nv) => (bo as RadioButton).SetCircleSize((double)nv));
+        public static readonly BindableProperty LabelPositionProperty = BindableProperty.Create(
+            propertyName: nameof(LabelPosition), declaringType: typeof(RadioButton),
+            returnType: typeof(LabelPosition), defaultBindingMode: BindingMode.TwoWay,
+            defaultValue: GlobalSetting.LabelPosition, 
+            propertyChanged: (bo, ov, nv) => (bo as RadioButton).ApplyLabelPosition((LabelPosition)nv));
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
         #endregion
 
         #region Methods
+        private void ApplyLabelPosition(LabelPosition position)
+        {
+            Children.Clear();
+            if (position == LabelPosition.After)
+            {
+                lblText.HorizontalOptions = LayoutOptions.Start;
+                Children.Add(IconLayout);
+                Children.Add(lblText);
+            }
+            else
+            {
+                lblText.HorizontalOptions = LayoutOptions.StartAndExpand;
+                Children.Add(lblText);
+                Children.Add(IconLayout);
+            }
+        }
         //-----------------------------------------------------------------------------
         /// <summary>
         /// That handles tapps and triggers event, commands etc.

--- a/InputKit/Shared/Controls/RadioButton.cs
+++ b/InputKit/Shared/Controls/RadioButton.cs
@@ -30,7 +30,7 @@ namespace Plugin.InputKit.Shared.Controls
             Size = Device.GetNamedSize(Device.RuntimePlatform == Device.iOS ? NamedSize.Large : NamedSize.Medium, typeof(Label)) * 1.2,
             CornerRadius = -1,
             FontSize = Device.GetNamedSize(Device.RuntimePlatform == Device.iOS ? NamedSize.Medium : NamedSize.Small, typeof(Label)),
-            LabelPosition = LabelPosition.Before
+            LabelPosition = LabelPosition.After
         };
         #endregion
 

--- a/InputKit/Shared/Controls/SelectionView.cs
+++ b/InputKit/Shared/Controls/SelectionView.cs
@@ -29,6 +29,7 @@ namespace Plugin.InputKit.Shared.Controls
             FontSize = Device.GetNamedSize(NamedSize.Default, typeof(Button)),
             Size = -1,
             TextColor = (Color)Button.TextColorProperty.DefaultValue,
+            LabelPosition = LabelPosition.After
         };
 
         #region Fields
@@ -151,6 +152,14 @@ namespace Plugin.InputKit.Shared.Controls
                         (item as SelectableButton).UnselectedColor = value;
             }
         }
+        /// <summary>
+        /// Gets or sets the label position.
+        /// </summary>
+        public LabelPosition LabelPosition
+        {
+            get => (LabelPosition)GetValue(LabelPositionProperty);
+            set => SetValue(LabelPositionProperty, value);
+        }
         //-----------------------------------------------------------------------------
         /// <summary>
         ///         Gets or sets a binding that selects the property that will be displayed for each
@@ -168,6 +177,11 @@ namespace Plugin.InputKit.Shared.Controls
         public static readonly BindableProperty SelectedIndexProperty = BindableProperty.Create(nameof(SelectedIndex), typeof(int), typeof(SelectionView), -1, BindingMode.TwoWay, propertyChanged: (bo, ov, nv) => (bo as SelectionView).SelectedIndex = (int)nv);
         public static readonly BindableProperty SelectedIndexesProperty = BindableProperty.Create(nameof(SelectedIndexes), typeof(IEnumerable<int>), typeof(SelectionView), new int[0], BindingMode.TwoWay, propertyChanged: (bo, ov, nv) => (bo as SelectionView).SelectedIndexes = (IEnumerable<int>)nv);
         public static new readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(SelectionView), SelectionView.GlobalSetting.BackgroundColor, propertyChanged: (bo, ov, nv) => (bo as SelectionView).BackgroundColor = (Color)nv);
+        public static readonly BindableProperty LabelPositionProperty = BindableProperty.Create(
+            propertyName: nameof(LabelPosition), declaringType: typeof(SelectionView),
+            returnType: typeof(LabelPosition), defaultBindingMode: BindingMode.TwoWay,
+            defaultValue: GlobalSetting.LabelPosition,
+            propertyChanged: (bo, ov, nv) => (bo as SelectionView).UpdateView());
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
         #endregion
 
@@ -263,14 +277,24 @@ namespace Plugin.InputKit.Shared.Controls
             {
                 case SelectionType.Button:
                 case SelectionType.MultipleButton:
-                    var btn = new SelectableButton(obj, this.Color);
-                    btn.UnselectedColor = this.BackgroundColor;
-                    btn.CanChangeSelectedState = SelectionType == SelectionType.MultipleButton;
+                    var btn = new SelectableButton(obj, this.Color)
+                    {
+                        UnselectedColor = this.BackgroundColor,
+                        CanChangeSelectedState = SelectionType == SelectionType.MultipleButton
+                    };
                     return btn;
                 case SelectionType.RadioButton:
-                    return new SelectableRadioButton(obj, this.Color);
+                    var rb = new SelectableRadioButton(obj, this.Color)
+                    {
+                        LabelPosition = LabelPosition
+                    };
+                    return rb;
                 case SelectionType.CheckBox:
-                    return new SelectableCheckBox(obj, this.Color);
+                    var cb = new SelectableCheckBox(obj, this.Color)
+                    {
+                        LabelPosition = LabelPosition
+                    };
+                    return cb;
             }
             return null;
         }

--- a/InputKit/Shared/LabelPosition.cs
+++ b/InputKit/Shared/LabelPosition.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Plugin.InputKit.Shared
+{
+    public enum LabelPosition
+    {
+        Before,
+        After
+    }
+}

--- a/Sample.InputKit/Sample.InputKit/Views/CheckBoxesPage.xaml
+++ b/Sample.InputKit/Sample.InputKit/Views/CheckBoxesPage.xaml
@@ -10,13 +10,14 @@
             x:Name="mainLayout"
             Padding="25"
             Spacing="15">
-            
-            <input:CheckBox Text="Option 0 with Box Type" Type="Box"  />
+
+            <input:CheckBox Text="Option 0 with Box Type" Type="Box" LabelPosition="After"/>
             <input:CheckBox Text="Option 1 with Check Type" Type="Check"/>
             <input:CheckBox Text="Option 2 wity Cross Type" Type="Cross"/>
             <input:CheckBox Text="Option 3 with Custom Type" Type="Custom" CustomIcon="ic_account_balance_black"/>
             <input:CheckBox Text="Option 4 with Material Type" Type="Material"/>
             <input:CheckBox Text="Option 5 with Star Type" Type="Star"/>
+            <input:CheckBox Text="Option 6 (Position)" Type="Check" CheckChanged="ChangePosition"/>
         </StackLayout>
     </ContentPage.Content>
 </ContentPage>

--- a/Sample.InputKit/Sample.InputKit/Views/CheckBoxesPage.xaml.cs
+++ b/Sample.InputKit/Sample.InputKit/Views/CheckBoxesPage.xaml.cs
@@ -31,5 +31,14 @@ namespace Sample.InputKit.Views
                 }
             }
         }
+
+        private void ChangePosition(object sender, EventArgs e)
+        {
+            if (sender is CheckBox cb)
+            {
+                cb.LabelPosition = cb.IsChecked ? Plugin.InputKit.Shared.LabelPosition.After :
+                                                  Plugin.InputKit.Shared.LabelPosition.Before;
+            }
+        }
     }
 }

--- a/Sample.InputKit/Sample.InputKit/Views/RadioButtonsPage.xaml
+++ b/Sample.InputKit/Sample.InputKit/Views/RadioButtonsPage.xaml
@@ -10,9 +10,9 @@
             <Button Text="Randomize Colors" Clicked="RandomizeColors" />
 
             <input:RadioButtonGroupView x:Name="groupView">
-                <input:RadioButton Text="Option 1"/>
-                <input:RadioButton Text="Option 2"/>
-                <input:RadioButton Text="Option 3"/>
+                <input:RadioButton Text="Option 1" LabelPosition="After"/>
+                <input:RadioButton Text="Option 2" LabelPosition="Before"/>
+                <input:RadioButton Text="Option 3 (Click me ^_^)" Clicked="ChangePosition"/>
                 <input:RadioButton Text="Option 4 with Custom Image" CheckedImage="circle_check"/>
                 <input:RadioButton Text="Dolor ullamcorper sit justo magna luptatum at sit dolor sed accusam amet quod nostrud lobortis amet dolore et zzril et"/>
                 <input:RadioButton Text="Option 5 Disabled" IsDisabled="True"/>

--- a/Sample.InputKit/Sample.InputKit/Views/RadioButtonsPage.xaml.cs
+++ b/Sample.InputKit/Sample.InputKit/Views/RadioButtonsPage.xaml.cs
@@ -31,5 +31,20 @@ namespace Sample.InputKit.Views
                 }
             }
         }
+
+        private void ChangePosition(object sender, EventArgs e)
+        {
+            if (sender is RadioButton rb)
+            {
+                if (rb.LabelPosition == Plugin.InputKit.Shared.LabelPosition.After)
+                {
+                    rb.LabelPosition = Plugin.InputKit.Shared.LabelPosition.Before;
+                }
+                else
+                {
+                    rb.LabelPosition = Plugin.InputKit.Shared.LabelPosition.After;
+                }
+            }
+        }
     }
 }

--- a/Sample.InputKit/Sample.InputKit/Views/SelectionViewPage.xaml
+++ b/Sample.InputKit/Sample.InputKit/Views/SelectionViewPage.xaml
@@ -17,6 +17,7 @@
                                  ColumnNumber="2" 
                                  RowSpacing="10" 
                                  ColumnSpacing="10"
+                                 LabelPosition="Before"
                                  SelectionType="Button" 
                                  ItemDisplayBinding="{Binding Name}" 
                                  ItemsSource="{Binding MyList}" />


### PR DESCRIPTION
add LabelPosition property to RadioButton and CheckBox controls, so we can specify the label's position (after or before).