### PR TITLE
Added default empty constructor

### DIFF
--- a/InputKit/Platforms/Droid/MenuEffect.cs
+++ b/InputKit/Platforms/Droid/MenuEffect.cs
@@ -15,6 +15,11 @@ namespace Plugin.InputKit.Platforms.Droid
     {
         PopupMenu ToggleMenu;
         InternalPopupEffect Effect;
+        
+        public MenuEffect()
+        {
+        }
+        
         protected override void OnAttached()
         {
             Effect = (InternalPopupEffect)Element.Effects.FirstOrDefault(e => e is InternalPopupEffect);


### PR DESCRIPTION
When the linker settings of a project is set to full, the app crashes and complains of a missing default constructor for this class.