### PR TITLE
Check for nulls in SetSelectedItems

### DIFF
--- a/InputKit/Shared/Controls/SelectionView.cs
+++ b/InputKit/Shared/Controls/SelectionView.cs
@@ -381,7 +381,7 @@ namespace Plugin.InputKit.Shared.Controls
         private void SetSelectedItems(IList value)
         {
             foreach (var item in this.Children)
-                if (item is ISelection selection)
+                if (item is ISelection selection && value != null)
                     (item as ISelection).IsSelected = value.Contains(selection.Value);
 
             if (value is INotifyCollectionChanged observable)


### PR DESCRIPTION
I was running into a crash when I was getting the selected items in my view model. The value has was coming through as null. Not sure if this is the root cause of the issue but it does fix it for me