### PR TITLE
AdvancedEntry Annotation RegEx not working

### DIFF
--- a/InputKit/Shared/Controls/AdvancedEntry.cs
+++ b/InputKit/Shared/Controls/AdvancedEntry.cs
@@ -34,10 +34,10 @@ namespace Plugin.InputKit.Shared.Controls
         #endregion
 
         #region Constants
-        public const string REGEX_LETTERONLY = "[A-Za-z]";
-        public const string REGEX_NONDIGITS = "[^0-9]";
-        public const string REGEX_DIGITSONLY = "[0-9]";
-        public const string REGEX_DECIMAL = "\\d+(\\.|,\\d{1,2})?";
+        public const string REGEX_LETTERONLY = "^[A-Za-z]*$";
+        public const string REGEX_NONDIGITS = "^[^0-9]*$";
+        public const string REGEX_DIGITSONLY = "^[0-9]*$";
+        public const string REGEX_DECIMAL = "^\\d+((\\.|,)\\d+)?$";
         public const string REGEX_EMAIL = @"^\w+([-+.']\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$";
         public const string REGEX_PASSWORD = "^(((?=.*[a-z])(?=.*[A-Z]))|((?=.*[a-z])(?=.*[0-9]))|((?=.*[A-Z])(?=.*[0-9])))(?=.{6,})";
         public const string REGEX_PHONE = "^[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\\s\\./0-9]*$";


### PR DESCRIPTION
The RegEx for the Advanced Entry was not working correctly.
See [Issue 181](https://github.com/enisn/Xamarin.Forms.InputKit/issues/181).