### PR TITLE
MAUI Preview 11

### DIFF
--- a/InputKit/Platforms/iOS/Controls/AutoCompleteTextField.cs
+++ b/InputKit/Platforms/iOS/Controls/AutoCompleteTextField.cs
@@ -6,6 +6,7 @@ using CoreGraphics;
 using Foundation;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Compatibility.Platform.iOS;
+using ObjCRuntime;
 using Plugin.InputKit.Platforms.iOS.Helpers;
 using UIKit;
 

--- a/src/InputKit/InputKit.csproj
+++ b/src/InputKit/InputKit.csproj
@@ -5,7 +5,7 @@
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<PackageId>Xamarin.Forms.InputKit</PackageId>
-		<Version>4.0.0-pre.2</Version>
+		<Version>4.0.0-pre.3</Version>
 
 		<!-- NuGet Package Info -->
 		 <PackageLicenseUrl></PackageLicenseUrl>

--- a/src/InputKit/Platforms/Android/Handlers/StatefulStackLayoutHandler.Android.cs
+++ b/src/InputKit/Platforms/Android/Handlers/StatefulStackLayoutHandler.Android.cs
@@ -2,6 +2,7 @@
 using Java.Interop;
 using Microsoft.Maui;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
 using System;
 
 namespace InputKit.Handlers

--- a/src/InputKit/Platforms/iOS/Handlers/StatefulStackLayoutHandler.iOS.cs
+++ b/src/InputKit/Platforms/iOS/Handlers/StatefulStackLayoutHandler.iOS.cs
@@ -1,6 +1,7 @@
 ﻿using Foundation;
 using Microsoft.Maui;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Platform;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;


### PR DESCRIPTION
Could you please release new NuGet version, built using Preview 11?
There's an issue in it where MAUI projects that are built using preview 11, cannot include NuGets that are built using earlier versions: https://github.com/dotnet/maui/issues/3965

**Note**: There are still warnings about `StackLayout` being deprecated in favor of `Grid`, but everything builds successfully.