### PR TITLE
Maui Advanced Slider

### DIFF
--- a/sandbox/SandboxMAUI/MainPage.xaml
+++ b/sandbox/SandboxMAUI/MainPage.xaml
@@ -14,6 +14,7 @@
             <Button Text="Radio Button" Clicked="GoToRadioButtonPage" />
 
             <Button Text="Advanced Entry &amp; FormView" Clicked="GoToAdvancedEntryPage" />
+            <Button Text="Advanced Slider" Clicked="GoToAdvancedSliderPage" />
 
         </StackLayout>
     </ScrollView>

--- a/sandbox/SandboxMAUI/MainPage.xaml.cs
+++ b/sandbox/SandboxMAUI/MainPage.xaml.cs
@@ -5,26 +5,31 @@ using SandboxMAUI.Pages;
 
 namespace SandboxMAUI
 {
-	public partial class MainPage : ContentPage
-	{
-		public MainPage()
-		{
-			InitializeComponent();
-		}
+    public partial class MainPage : ContentPage
+    {
+        public MainPage()
+        {
+            InitializeComponent();
+        }
 
         async void GoToCheckBoxPage(System.Object sender, System.EventArgs e)
         {
-			await Navigation.PushAsync(new CheckBoxPage());
+            await Navigation.PushAsync(new CheckBoxPage());
         }
 
         async void GoToRadioButtonPage(System.Object sender, System.EventArgs e)
-		{
-			await Navigation.PushAsync(new RadioButtonPage());
-		}
+        {
+            await Navigation.PushAsync(new RadioButtonPage());
+        }
 
         async void GoToAdvancedEntryPage(System.Object sender, System.EventArgs e)
-		{
-			await Navigation.PushAsync(new AdvancedEntryPage());
-		}
+        {
+            await Navigation.PushAsync(new AdvancedEntryPage());
+        }
+
+        async void GoToAdvancedSliderPage(System.Object sender, System.EventArgs e)
+        {
+            await Navigation.PushAsync(new AdvancedSliderPage());
+        }
     }
 }

--- a/sandbox/SandboxMAUI/Pages/AdvancedSliderPage.xaml
+++ b/sandbox/SandboxMAUI/Pages/AdvancedSliderPage.xaml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:input="clr-namespace:InputKit.Shared.Controls;assembly=InputKit"
+             x:Class="SandboxMAUI.Pages.AdvancedSliderPage"
+             Title="AdvancedSliderPage">
+    <ScrollView>
+        <StackLayout Padding="25" Spacing="15">
+            
+            <input:AdvancedSlider MaxValue="5000" 
+                                  MinValue="50" 
+                                  StepValue="50" 
+                                  Value="{Binding Price}" 
+                                  ValuePrefix="Offer:" 
+                                  ValueSuffix="$" 
+                                  Title="Choose Budget:"/>
+
+        </StackLayout>
+    </ScrollView>
+</ContentPage>

--- a/sandbox/SandboxMAUI/Pages/AdvancedSliderPage.xaml.cs
+++ b/sandbox/SandboxMAUI/Pages/AdvancedSliderPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace SandboxMAUI.Pages;
+
+public partial class AdvancedSliderPage : ContentPage
+{
+	public AdvancedSliderPage()
+	{
+		InitializeComponent();
+	}
+}

--- a/src/InputKit/Shared/Controls/AdvancedSlider.cs
+++ b/src/InputKit/Shared/Controls/AdvancedSlider.cs
@@ -202,10 +202,17 @@ public partial class AdvancedSlider : StackLayout, IValidatable
     {
         var totalLength = MaxValue - MinValue;
         var normalizedValue = Value - MinValue;
-        lblValue.TranslateTo(
-            normalizedValue * ((slider.Width - 30) / totalLength), //pos X  /* -30 is used to make smaller label horizontal movable region and prevent touching minValue and maxValue labels*/
-            slider.TranslationY - lblValue.Height * 0.9, //pos Y
-            40 //Latency
-            );
+
+
+        // TODO: Keep animation disabled until resolution of https://github.com/dotnet/maui/issues/3353
+
+        lblValue.TranslationX = normalizedValue * ((slider.Width - 30) / totalLength);
+        lblValue.TranslationY = slider.TranslationY - lblValue.Height * 0.9;
+
+        //lblValue.TranslateTo(
+        //    normalizedValue * ((slider.Width - 30) / totalLength), //pos X  /* -30 is used to make smaller label horizontal movable region and prevent touching minValue and maxValue labels*/
+        //    slider.TranslationY - lblValue.Height * 0.9, //pos Y
+        //    40 //Latency
+        //    );
     }
 }


### PR DESCRIPTION
Closes #243 

---

- Added AdvancedSliderPage
   - following page built with:
   ```xml
   <input:AdvancedSlider MaxValue="5000" 
                                    MinValue="50" 
                                    StepValue="50" 
                                    Value="{Binding Price}" 
                                    ValuePrefix="Offer:" 
                                    ValueSuffix="$" 
                                    Title="Choose Budget:"/>
   ```
  ![advanced-slider-page](https://user-images.githubusercontent.com/23705418/158016314-b01d1053-a123-4713-999c-987523a7f97a.gif)

- Removed animation until resolution of https://github.com/dotnet/maui/issues/3353
