### PR TITLE
Separate Predefined Shapes from Controls

### DIFF
--- a/sandbox/SandboxMAUI/MainPage.xaml
+++ b/sandbox/SandboxMAUI/MainPage.xaml
@@ -5,6 +5,7 @@
 
     <ScrollView>
         <StackLayout
+            x:Name="mainLayout"
               Padding="{OnPlatform iOS='30,60,30,30', Default='30'}" Spacing="10"
               MaximumWidthRequest="400">
 

--- a/sandbox/SandboxMAUI/MainPage.xaml.cs
+++ b/sandbox/SandboxMAUI/MainPage.xaml.cs
@@ -10,7 +10,6 @@ public partial class MainPage : ContentPage
         InitializeComponent();
     }
 
-
     async void GoToCheckBoxPage(System.Object sender, System.EventArgs e)
     {
         await Navigation.PushAsync(new CheckBoxPage());

--- a/sandbox/SandboxMAUI/MainPage.xaml.cs
+++ b/sandbox/SandboxMAUI/MainPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using SandboxMAUI.Pages;
+﻿using Microsoft.Maui.Controls;
+using SandboxMAUI.Pages;
 
 namespace SandboxMAUI;
 
@@ -8,9 +9,13 @@ public partial class MainPage : ContentPage
     {
         InitializeComponent();
     }
+
+
     async void GoToCheckBoxPage(System.Object sender, System.EventArgs e)
     {
         await Navigation.PushAsync(new CheckBoxPage());
+
+        mainLayout.HorizontalOptions = LayoutOptions.Center;
     }
 
     async void GoToRadioButtonPage(System.Object sender, System.EventArgs e)

--- a/sandbox/SandboxMAUI/Pages/CheckBoxPage.xaml
+++ b/sandbox/SandboxMAUI/Pages/CheckBoxPage.xaml
@@ -2,8 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:input="clr-namespace:InputKit.Shared.Controls;assembly=InputKit.Maui"
              x:Class="SandboxMAUI.Pages.CheckBoxPage"
-             Title="CheckBoxPage"
-             BackgroundColor="White">
+             Title="CheckBoxPage">
     <ScrollView>
         <StackLayout
             x:Name="mainLayout"
@@ -13,15 +12,16 @@
 
             <Button Text="Randomize colors" Clicked="Button_Clicked" />
 
-            <BoxView Color="Black" HeightRequest="1" HorizontalOptions="Fill" Margin="5,10" />
+            <BoxView Color="{AppThemeBinding Dark=White, Light=Black}" HeightRequest="1" HorizontalOptions="Fill" Margin="5,10" />
 
-            <input:CheckBox Text="Option 0 with Box Type" Type="Box"/>
-            <input:CheckBox Text="Option 1 with Check Type" Type="Check" />
-            <input:CheckBox Text="Option 2 with Line Type" Type="Line" />
-            <input:CheckBox Text="Option 3 with Material Type" Type="Material" />
-            <input:CheckBox Text="Option 4 with Custom Type (X)" Type="Custom" CustomIconGeometry="M17.705 7.705l-1.41-1.41L12 10.59 7.705 6.295l-1.41 1.41L10.59 12l-4.295 4.295 1.41 1.41L12 13.41l4.295 4.295 1.41-1.41L13.41 12l4.295-4.295z"/>
-            <input:CheckBox Text="Option 5 with Material Custom Type (X)" Type="Material" CustomIconGeometry="M17.705 7.705l-1.41-1.41L12 10.59 7.705 6.295l-1.41 1.41L10.59 12l-4.295 4.295 1.41 1.41L12 13.41l4.295 4.295 1.41-1.41L13.41 12l4.295-4.295z"/>
-            <input:CheckBox Text="Option 6 (Position)" Type="Check" LabelPosition="Before"/>
+            <input:CheckBox Text="Option 0 Plain Checkbox" />
+            <input:CheckBox Text="Option 1 with Filled Type" Type="Filled" />
+            <input:CheckBox Text="Option 2 with Material Type" Type="Material" />
+            <input:CheckBox Text="Option 3 with Line Shape" IconGeometry="{x:Static input:PredefinedShapes.Line}" />
+            <input:CheckBox Text="Option 3 with Line Shape with Material Type" Type="Material" IconGeometry="{x:Static input:PredefinedShapes.Line}" />
+            <input:CheckBox Text="Option 3 with Custom Type (X)" Type="Custom" IconGeometry="M17.705 7.705l-1.41-1.41L12 10.59 7.705 6.295l-1.41 1.41L10.59 12l-4.295 4.295 1.41 1.41L12 13.41l4.295 4.295 1.41-1.41L13.41 12l4.295-4.295z"/>
+            <input:CheckBox Text="Option 5 with Material Custom Type (X)" Type="Material" IconGeometry="M17.705 7.705l-1.41-1.41L12 10.59 7.705 6.295l-1.41 1.41L10.59 12l-4.295 4.295 1.41 1.41L12 13.41l4.295 4.295 1.41-1.41L13.41 12l4.295-4.295z"/>
+            <input:CheckBox Text="Option 6 (Position)" Type="Regular" LabelPosition="Before"/>          
 
         </StackLayout>
     </ScrollView>

--- a/sandbox/SandboxMAUI/Pages/CheckBoxPage.xaml
+++ b/sandbox/SandboxMAUI/Pages/CheckBoxPage.xaml
@@ -17,6 +17,7 @@
             <input:CheckBox Text="Option 0 Plain Checkbox" />
             <input:CheckBox Text="Option 1 with Filled Type" Type="Filled" />
             <input:CheckBox Text="Option 2 with Material Type" Type="Material" />
+            <input:CheckBox Text="Option 2 with Square Shape" IconGeometry="{x:Static input:PredefinedShapes.Square}" />
             <input:CheckBox Text="Option 3 with Line Shape" IconGeometry="{x:Static input:PredefinedShapes.Line}" />
             <input:CheckBox Text="Option 3 with Line Shape with Material Type" Type="Material" IconGeometry="{x:Static input:PredefinedShapes.Line}" />
             <input:CheckBox Text="Option 3 with Custom Type (X)" Type="Custom" IconGeometry="M17.705 7.705l-1.41-1.41L12 10.59 7.705 6.295l-1.41 1.41L10.59 12l-4.295 4.295 1.41 1.41L12 13.41l4.295 4.295 1.41-1.41L13.41 12l4.295-4.295z"/>

--- a/sandbox/SandboxMAUI/Pages/RadioButtonPage.xaml
+++ b/sandbox/SandboxMAUI/Pages/RadioButtonPage.xaml
@@ -8,15 +8,16 @@
         <StackLayout Padding="25" Spacing="15" MaximumWidthRequest="400">
 
             <Button Text="Randomize Colors" Clicked="RandomizeColors" />
-            <BoxView Color="Black" HeightRequest="1" HorizontalOptions="Fill" Margin="5,10" />
+            <BoxView Color="{AppThemeBinding Dark=White, Light=Black}" HeightRequest="1" HorizontalOptions="Fill" Margin="5,10" />
 
             <input:RadioButtonGroupView x:Name="groupView">
                 <input:RadioButton Text="Option 1" />
                 <input:RadioButton Text="Option 2" />
-                <input:RadioButton Text="Option 3 Label Position Before" LabelPosition="Before"/>
-                <input:RadioButton Text="Option 4 with Custom Image" SelectedIconGeomerty="M12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 Z M8,10 L6,12 L11,17 L18,10 L16,8 L11,13 L8,10 Z"/>
-                <input:RadioButton Text="Dolor ullamcorper sit justo magna "/>
-                <input:RadioButton Text="Option 5 Disabled" IsDisabled="True"/>
+                <input:RadioButton Text="Option 3 with Check Shape" SelectedIconGeomerty="{x:Static input:PredefinedShapes.Check}" />
+                <input:RadioButton Text="Option 4 with CheckCircle Shape" SelectedIconGeomerty="{x:Static input:PredefinedShapes.CheckCircle}"/>
+                <input:RadioButton Text="Option 5 with Custom Shape" SelectedIconGeomerty="M 15.6038 7.1366 v 5.8061 c 0 0.8669 -0.8266 1.6934 -1.6934 1.6934 h -5.0803 c -1.0547 0 -1.9094 -0.1302 -2.903 -0.4838 c -0.3068 -0.1092 -1.2096 -0.4838 -1.2096 -0.4838 V 6.8947 l 3.9939 -4.6913 L 9.072 0.121 h 0.7258 c 0.804 0 1.3703 0.6415 1.3703 1.4456 v 0.4522 c 0 1.0321 -0.0622 2.0633 -0.1862 3.0879 L 10.9412 5.4432 H 13.9104 C 14.7773 5.4432 15.6038 6.2698 15.6038 7.1366 z M 0.121 14.3942 h 3.6288 V 6.169 H 0.121 V 14.3942 z"/>
+                <input:RadioButton Text="Option 6 Label Position Before" LabelPosition="Before"/>
+                <input:RadioButton Text="Option 7 Disabled" IsDisabled="True"/>
             </input:RadioButtonGroupView>
 
         </StackLayout>

--- a/src/InputKit.Maui/Shared/Controls/CheckBox.cs
+++ b/src/InputKit.Maui/Shared/Controls/CheckBox.cs
@@ -19,7 +19,7 @@ public partial class CheckBox : StatefulStackLayout, IValidatable
     {
         BackgroundColor = Colors.Transparent,
         Color = InputKitOptions.GetAccentColor(),
-        BorderColor = Colors.Black
+        BorderColor = Colors.Black,
         TextColor = (Color)Label.TextColorProperty.DefaultValue,
         Size = 25,
         CornerRadius = 2,

--- a/src/InputKit.Maui/Shared/Controls/PredefinedShapes.cs
+++ b/src/InputKit.Maui/Shared/Controls/PredefinedShapes.cs
@@ -1,0 +1,21 @@
+﻿using InputKit.Shared.Helpers;
+using Microsoft.Maui.Controls.Shapes;
+
+namespace InputKit.Shared.Controls;
+public static class PredefinedShapes
+{
+    public static Geometry Check = GeometryConverter.FromPath(Paths.Check);
+    public static Geometry CheckCircle = GeometryConverter.FromPath(Paths.CheckCircle);
+    public static Geometry Line = GeometryConverter.FromPath(Paths.LineHorizontal);
+    public static Geometry Square = GeometryConverter.FromPath(Paths.LineHorizontal);
+    public static Geometry Dot = GeometryConverter.FromPath(Paths.Dot);
+}
+
+public static class Paths
+{
+    public const string Check = "M 6.5212 16.4777 l -6.24 -6.24 c -0.3749 -0.3749 -0.3749 -0.9827 0 -1.3577 l 1.3576 -1.3577 c 0.3749 -0.3749 0.9828 -0.3749 1.3577 0 L 7.2 11.7259 L 16.2036 2.7224 c 0.3749 -0.3749 0.9828 -0.3749 1.3577 0 l 1.3576 1.3577 c 0.3749 0.3749 0.3749 0.9827 0 1.3577 l -11.04 11.04 c -0.3749 0.3749 -0.9828 0.3749 -1.3577 -0 z";
+    public const string CheckCircle = "M12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 Z M8,10 L6,12 L11,17 L18,10 L16,8 L11,13 L8,10 Z";
+    public const string Square = "M12 12H0V0h12v12z";
+    public const string LineHorizontal = "M 17.2026 6.7911 H 0.9875 C 0.4422 6.7911 0 7.2332 0 7.7784 v 2.6331 c 0 0.5453 0.442 0.9873 0.9875 0.9873 h 16.2151 c 0.5453 0 0.9873 -0.442 0.9873 -0.9873 v -2.6331 C 18.1901 7.2332 17.7481 6.7911 17.2026 6.7911 z";
+    public const string Dot = "M12 18a6 6 0 100-12 6 6 0 000 12z";
+}

--- a/src/InputKit.Maui/Shared/Controls/PredefinedShapes.cs
+++ b/src/InputKit.Maui/Shared/Controls/PredefinedShapes.cs
@@ -7,7 +7,7 @@ public static class PredefinedShapes
     public static Geometry Check = GeometryConverter.FromPath(Paths.Check);
     public static Geometry CheckCircle = GeometryConverter.FromPath(Paths.CheckCircle);
     public static Geometry Line = GeometryConverter.FromPath(Paths.LineHorizontal);
-    public static Geometry Square = GeometryConverter.FromPath(Paths.LineHorizontal);
+    public static Geometry Square = GeometryConverter.FromPath(Paths.Square);
     public static Geometry Dot = GeometryConverter.FromPath(Paths.Dot);
 }
 

--- a/src/InputKit.Maui/Shared/Controls/PredefinedShapes.cs
+++ b/src/InputKit.Maui/Shared/Controls/PredefinedShapes.cs
@@ -9,13 +9,13 @@ public static class PredefinedShapes
     public static Geometry Line = GeometryConverter.FromPath(Paths.LineHorizontal);
     public static Geometry Square = GeometryConverter.FromPath(Paths.Square);
     public static Geometry Dot = GeometryConverter.FromPath(Paths.Dot);
-}
 
-public static class Paths
-{
-    public const string Check = "M 6.5212 16.4777 l -6.24 -6.24 c -0.3749 -0.3749 -0.3749 -0.9827 0 -1.3577 l 1.3576 -1.3577 c 0.3749 -0.3749 0.9828 -0.3749 1.3577 0 L 7.2 11.7259 L 16.2036 2.7224 c 0.3749 -0.3749 0.9828 -0.3749 1.3577 0 l 1.3576 1.3577 c 0.3749 0.3749 0.3749 0.9827 0 1.3577 l -11.04 11.04 c -0.3749 0.3749 -0.9828 0.3749 -1.3577 -0 z";
-    public const string CheckCircle = "M12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 Z M8,10 L6,12 L11,17 L18,10 L16,8 L11,13 L8,10 Z";
-    public const string Square = "M12 12H0V0h12v12z";
-    public const string LineHorizontal = "M 17.2026 6.7911 H 0.9875 C 0.4422 6.7911 0 7.2332 0 7.7784 v 2.6331 c 0 0.5453 0.442 0.9873 0.9875 0.9873 h 16.2151 c 0.5453 0 0.9873 -0.442 0.9873 -0.9873 v -2.6331 C 18.1901 7.2332 17.7481 6.7911 17.2026 6.7911 z";
-    public const string Dot = "M12 18a6 6 0 100-12 6 6 0 000 12z";
+    public static class Paths
+    {
+        public const string Check = "M 6.5212 16.4777 l -6.24 -6.24 c -0.3749 -0.3749 -0.3749 -0.9827 0 -1.3577 l 1.3576 -1.3577 c 0.3749 -0.3749 0.9828 -0.3749 1.3577 0 L 7.2 11.7259 L 16.2036 2.7224 c 0.3749 -0.3749 0.9828 -0.3749 1.3577 0 l 1.3576 1.3577 c 0.3749 0.3749 0.3749 0.9827 0 1.3577 l -11.04 11.04 c -0.3749 0.3749 -0.9828 0.3749 -1.3577 -0 z";
+        public const string CheckCircle = "M12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 Z M8,10 L6,12 L11,17 L18,10 L16,8 L11,13 L8,10 Z";
+        public const string Square = "M12 12H0V0h12v12z";
+        public const string LineHorizontal = "M 17.2026 6.7911 H 0.9875 C 0.4422 6.7911 0 7.2332 0 7.7784 v 2.6331 c 0 0.5453 0.442 0.9873 0.9875 0.9873 h 16.2151 c 0.5453 0 0.9873 -0.442 0.9873 -0.9873 v -2.6331 C 18.1901 7.2332 17.7481 6.7911 17.2026 6.7911 z";
+        public const string Dot = "M12 18a6 6 0 100-12 6 6 0 000 12z";
+    }
 }

--- a/src/InputKit.Maui/Shared/Controls/RadioButton.cs
+++ b/src/InputKit.Maui/Shared/Controls/RadioButton.cs
@@ -29,10 +29,6 @@ public class RadioButton : StatefulStackLayout
     };
     #endregion
 
-    #region Constants
-    public const string PATH_DOT = "M12 18a6 6 0 100-12 6 6 0 000 12z";
-    #endregion
-
     #region Fields
     protected internal Grid IconLayout;
     protected internal Ellipse iconCircle = new Ellipse
@@ -92,7 +88,7 @@ public class RadioButton : StatefulStackLayout
         };
 
         ApplyLabelPosition(LabelPosition);
-        UpdateType();
+        UpdateShape();
 
         GestureRecognizers.Add(new TapGestureRecognizer { Command = new Command(Tapped) });
     }
@@ -220,7 +216,7 @@ public class RadioButton : StatefulStackLayout
     public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(RadioButton), propertyChanged: (bo, ov, nv) => (bo as RadioButton).CommandParameter = nv);
     public static readonly BindableProperty IsPressedProperty = BindableProperty.Create(nameof(IsPressed), typeof(bool), typeof(RadioButton), propertyChanged: (bo, ov, nv) => (bo as RadioButton).ApplyIsPressedAction((bool)nv));
     public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create(nameof(FontFamily), typeof(string), typeof(RadioButton), propertyChanged: (bo, ov, nv) => (bo as RadioButton).FontFamily = (string)nv);
-    public static readonly BindableProperty SelectedIconGeomertyProperty = BindableProperty.Create(nameof(SelectedIconGeomerty), typeof(Geometry), typeof(RadioButton), GeometryConverter.FromPath(PATH_DOT), propertyChanged: (bo, ov, nv) => (bo as RadioButton).UpdateType());
+    public static readonly BindableProperty SelectedIconGeomertyProperty = BindableProperty.Create(nameof(SelectedIconGeomerty), typeof(Geometry), typeof(RadioButton), PredefinedShapes.Dot, propertyChanged: (bo, ov, nv) => (bo as RadioButton).UpdateShape());
     public static readonly BindableProperty LabelPositionProperty = BindableProperty.Create(
         propertyName: nameof(LabelPosition), declaringType: typeof(RadioButton),
         returnType: typeof(LabelPosition), defaultBindingMode: BindingMode.TwoWay,
@@ -235,19 +231,19 @@ public class RadioButton : StatefulStackLayout
         Children.Clear();
         if (position == LabelPosition.After)
         {
-            IconLayout.HorizontalOptions = LayoutOptions.Center;
+            lblText.HorizontalOptions = LayoutOptions.Start;
             Children.Add(IconLayout);
             Children.Add(lblText);
         }
         else
         {
-            IconLayout.HorizontalOptions = LayoutOptions.Center;
+            lblText.HorizontalOptions = LayoutOptions.FillAndExpand;
             Children.Add(lblText);
             Children.Add(IconLayout);
         }
     }
 
-    private protected virtual void UpdateType()
+    private protected virtual void UpdateShape()
     {
         iconChecked.Data = SelectedIconGeomerty;
     }


### PR DESCRIPTION
Introducing Predefined shapes.

`PredefinesShapes` is a class that allow you to access shapes which is used in CmsKit and existing shapes can be used across controls.

 i.e. RadioButton can used Check shapes of Checkbox as selected icon with following code:

```xml
<input:RadioButton SelectedIconGeomerty="{x:Static input:PredefinedShapes.Check}"  Text="Option 3 with Check Shape"/>
```

![image](https://user-images.githubusercontent.com/23705418/187067791-0ae5709b-ae5d-4eb2-91ad-198939c6fb15.png)


## Breaking-Change

- `Type` property of `CheckBox` is no longer used to define shape. You have to use `IconGeometry` property to define shape of checkbox. You can use `PredefinedShapes` like following example:

```xml
<input:CheckBox Text="Option 2 with Square Shape" Type="{x:Static input:PredefinedShapes.Square}" />
```
![image](https://user-images.githubusercontent.com/23705418/187067981-2eb020b0-d39a-4af7-bf4a-831aad47ac74.png)

