### PR TITLE
IconView deprecated

### DIFF
--- a/src/InputKit.Maui/Shared/Controls/IconView.cs
+++ b/src/InputKit.Maui/Shared/Controls/IconView.cs
@@ -3,9 +3,7 @@ using Microsoft.Maui.Graphics;
 
 namespace InputKit.Shared.Controls;
 
-/// <summary>
-/// Default Constructor
-/// </summary>
+[Obsolete("IconView is deprecated. It won't be part of this library anymore. Please change your icons to FontImage or equivalent.")]
 public partial class IconView : View, IIconView
 {
     public IconView()


### PR DESCRIPTION


## Breaking-Change

- `IconView` is deprecated. It won't be part of this package in next versions. Please consider to change it FontImage or something equivalent.