### PR TITLE
Fix initial validation state

### DIFF
--- a/src/InputKit.Maui/Shared/Controls/AdvancedEntry.Validation.cs
+++ b/src/InputKit.Maui/Shared/Controls/AdvancedEntry.Validation.cs
@@ -92,16 +92,16 @@ public partial class AdvancedEntry : IValidatable
         CheckAndDisplayValidations();
     }
 
-    private bool lastValidationState = true;
+    private bool? _lastValidationState;
 
     protected virtual void CheckAndDisplayValidations()
     {
         var results = ValidationResults().ToArray();
         var isValidationPassed = results.All(a => a.isValid);
 
-        var isStateChanged = isValidationPassed != lastValidationState;
+        var isStateChanged = isValidationPassed != _lastValidationState;
 
-        lastValidationState = isValidationPassed;
+        _lastValidationState = isValidationPassed;
 
         if (isValidationPassed)
         {


### PR DESCRIPTION
This fixes an issue where if the user never submits an invalid form the `IsValid` property is never updated.

Sample repo: https://github.com/crobibero/input-kit-validation

Steps to reproduce:
1. Enter anything into entry
2. Submit
3. Notice "Not valid"
4. Clear entry
5. Submit
6. Notice "Is valid"