### PR TITLE
Add delay to checkbox on android for long texts

### DIFF
--- a/src/InputKit.Maui/Shared/Controls/CheckBox.cs
+++ b/src/InputKit.Maui/Shared/Controls/CheckBox.cs
@@ -357,12 +357,20 @@ public partial class CheckBox : StatefulStackLayout, IValidatable
         }
     }
 
-    protected override void OnSizeAllocated(double width, double height)
+    protected override async void OnSizeAllocated(double width, double height)
     {
+        base.OnSizeAllocated(width, height);
+
         // TODO: Remove this logic after resolution of https://github.com/dotnet/maui/issues/8873
         // This is a workaround.
-        lblOption.MaximumWidthRequest = this.Width - IconLayout.Width;
-        base.OnSizeAllocated(width, height);
+
+#if ANDROID
+        await Task.Delay(1);
+#endif
+        if (IconLayout.Width != -1 && lblOption.Width > this.Width)
+        {
+            lblOption.MaximumWidthRequest = this.Width - IconLayout.Width;
+        }
     }
 
     void ExecuteCommand()


### PR DESCRIPTION
Resolves https://github.com/enisn/UraniumUI/issues/276

![MAUI CheckBox text wrapping](https://user-images.githubusercontent.com/23705418/231427184-b1c9a6f3-ad98-4422-b1ba-4e5dde7d860f.png)
