### PR TITLE
Rel 4.2 radiobutton checkbox enhancements

### DIFF
--- a/src/InputKit.Maui/Shared/Configuration/GlobalSetting.cs
+++ b/src/InputKit.Maui/Shared/Configuration/GlobalSetting.cs
@@ -51,4 +51,9 @@ public class GlobalSetting
     /// Label position of control.
     /// </summary>
     public LabelPosition LabelPosition { get; set; }
+
+    /// <summary>
+    /// The line break mode for the text displayed by the control.
+    /// </summary>
+    public LineBreakMode LineBreakMode { get; set; }
 }

--- a/src/InputKit.Maui/Shared/Controls/CheckBox.cs
+++ b/src/InputKit.Maui/Shared/Controls/CheckBox.cs
@@ -26,7 +26,8 @@ public partial class CheckBox : StatefulStackLayout, IValidatable
         Size = 25,
         CornerRadius = 2,
         FontSize = 14,
-        LabelPosition = LabelPosition.After
+        LabelPosition = LabelPosition.After,
+        LineBreakMode = LineBreakMode.WordWrap
     };
 
     #region Constants
@@ -56,6 +57,7 @@ public partial class CheckBox : StatefulStackLayout, IValidatable
     };
     protected internal Label lblOption = new Label
     {
+        LineBreakMode = GlobalSetting.LineBreakMode,
         VerticalOptions = LayoutOptions.Center,
         HorizontalOptions = LayoutOptions.Start,
         FontSize = GlobalSetting.FontSize,
@@ -256,6 +258,11 @@ public partial class CheckBox : StatefulStackLayout, IValidatable
         set => SetValue(ValidationColorProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets the line break mode for the label.
+    /// </summary>
+    public LineBreakMode LineBreakMode { get => (LineBreakMode)GetValue(LineBreakModeProperty); set => SetValue(LineBreakModeProperty, value); }
+
     #endregion
 
     #region Validation
@@ -335,6 +342,9 @@ public partial class CheckBox : StatefulStackLayout, IValidatable
 
     public static readonly BindableProperty TypeProperty = BindableProperty.Create(nameof(Type), typeof(CheckType), typeof(CheckBox), defaultValue: CheckType.Regular,
         propertyChanged: (bindable, oldValue, newValue) => (bindable as CheckBox).UpdateType());
+
+    public static readonly BindableProperty LineBreakModeProperty = BindableProperty.Create(nameof(LineBreakMode), typeof(LineBreakMode), typeof(CheckBox), defaultValue: GlobalSetting.LineBreakMode,
+        propertyChanged: (bindable, oldValue, newValue) => (bindable as CheckBox).lblOption.LineBreakMode = (LineBreakMode)newValue);
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     #endregion
 

--- a/src/InputKit.Maui/Shared/Controls/CheckBox.cs
+++ b/src/InputKit.Maui/Shared/Controls/CheckBox.cs
@@ -88,6 +88,7 @@ public partial class CheckBox : StatefulStackLayout, IValidatable
             MinimumWidthRequest = GlobalSetting.Size,
             HeightRequest = GlobalSetting.Size,
             VerticalOptions = LayoutOptions.Center,
+            HorizontalOptions = LayoutOptions.Center,
             Children =
             {
                 outlineBox,
@@ -263,6 +264,15 @@ public partial class CheckBox : StatefulStackLayout, IValidatable
     /// </summary>
     public LineBreakMode LineBreakMode { get => (LineBreakMode)GetValue(LineBreakModeProperty); set => SetValue(LineBreakModeProperty, value); }
 
+    /// <summary>
+    /// Gets or sets the vertical options for the icon.
+    /// </summary>
+    public LayoutOptions IconVerticalOptions { get => (LayoutOptions)GetValue(IconVerticalOptionsProperty); set => SetValue(IconVerticalOptionsProperty, value); }
+
+    /// <summary>
+    /// Gets or sets the horizontal options for the icon.
+    /// </summary>
+    public LayoutOptions IconHorizontalOptions { get => (LayoutOptions)GetValue(IconHorizontalOptionsProperty); set => SetValue(IconHorizontalOptionsProperty, value); }
     #endregion
 
     #region Validation
@@ -345,6 +355,13 @@ public partial class CheckBox : StatefulStackLayout, IValidatable
 
     public static readonly BindableProperty LineBreakModeProperty = BindableProperty.Create(nameof(LineBreakMode), typeof(LineBreakMode), typeof(CheckBox), defaultValue: GlobalSetting.LineBreakMode,
         propertyChanged: (bindable, oldValue, newValue) => (bindable as CheckBox).lblOption.LineBreakMode = (LineBreakMode)newValue);
+
+    public static readonly BindableProperty IconVerticalOptionsProperty = BindableProperty.Create(nameof(IconVerticalOptions), typeof(LayoutOptions), typeof(CheckBox), defaultValue: LayoutOptions.Center,
+        propertyChanged: (bindable, oldValue, newValue) => (bindable as CheckBox).IconLayout.VerticalOptions = (LayoutOptions)newValue);
+
+    public static readonly BindableProperty IconHorizontalOptionsProperty = BindableProperty.Create(nameof(IconHorizontalOptions), typeof(LayoutOptions), typeof(CheckBox), defaultValue: LayoutOptions.Center,
+        propertyChanged: ( bindable, oldValue, newValue ) => (bindable as CheckBox).IconLayout.HorizontalOptions = (LayoutOptions)newValue);
+
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     #endregion
 

--- a/src/InputKit.Maui/Shared/Controls/CheckBox.cs
+++ b/src/InputKit.Maui/Shared/Controls/CheckBox.cs
@@ -369,7 +369,7 @@ public partial class CheckBox : StatefulStackLayout, IValidatable
 #endif
         if (IconLayout.Width != -1 && lblOption.Width > this.Width)
         {
-            lblOption.MaximumWidthRequest = this.Width - IconLayout.Width;
+            lblOption.MaximumWidthRequest = this.Width - this.Spacing - IconLayout.Width;
         }
     }
 

--- a/src/InputKit.Maui/Shared/Controls/RadioButton.cs
+++ b/src/InputKit.Maui/Shared/Controls/RadioButton.cs
@@ -82,6 +82,7 @@ public class RadioButton : StatefulStackLayout
         IconLayout = new Grid
         {
             VerticalOptions = LayoutOptions.Center,
+            HorizontalOptions = LayoutOptions.Center,
             Children =
             {
                 iconCircle,
@@ -221,6 +222,16 @@ public class RadioButton : StatefulStackLayout
     /// </summary>
     public LineBreakMode LineBreakMode { get => (LineBreakMode)GetValue(LineBreakModeProperty); set => SetValue(LineBreakModeProperty, value); }
 
+    /// <summary>
+    /// Gets or sets the vertical options for the icon.
+    /// </summary>
+    public LayoutOptions IconVerticalOptions { get => (LayoutOptions)GetValue(IconVerticalOptionsProperty); set => SetValue(IconVerticalOptionsProperty, value); }
+
+    /// <summary>
+    /// Gets or sets the horizontal options for the icon.
+    /// </summary>
+    public LayoutOptions IconHorizontalOptions { get => (LayoutOptions)GetValue(IconHorizontalOptionsProperty); set => SetValue(IconHorizontalOptionsProperty, value); }
+
     #endregion
 
     #region BindableProperties
@@ -246,6 +257,12 @@ public class RadioButton : StatefulStackLayout
 
     public static readonly BindableProperty LineBreakModeProperty = BindableProperty.Create(nameof(LineBreakMode), typeof(LineBreakMode), typeof(RadioButton), defaultValue: GlobalSetting.LineBreakMode,
         propertyChanged: ( bindable, oldValue, newValue ) => (bindable as RadioButton).lblText.LineBreakMode = (LineBreakMode)newValue);
+    
+    public static readonly BindableProperty IconVerticalOptionsProperty = BindableProperty.Create(nameof(IconVerticalOptions), typeof(LayoutOptions), typeof(RadioButton), defaultValue: LayoutOptions.Center,
+        propertyChanged: ( bindable, oldValue, newValue ) => (bindable as RadioButton).IconLayout.VerticalOptions = (LayoutOptions)newValue);
+
+    public static readonly BindableProperty IconHorizontalOptionsProperty = BindableProperty.Create(nameof(IconHorizontalOptions), typeof(LayoutOptions), typeof(RadioButton), defaultValue: LayoutOptions.Center,
+        propertyChanged: ( bindable, oldValue, newValue ) => (bindable as RadioButton).IconLayout.HorizontalOptions = (LayoutOptions)newValue);
 
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     #endregion

--- a/src/InputKit.Maui/Shared/Controls/RadioButton.cs
+++ b/src/InputKit.Maui/Shared/Controls/RadioButton.cs
@@ -58,7 +58,6 @@ public class RadioButton : StatefulStackLayout
         TextColor = GlobalSetting.TextColor,
         FontSize = GlobalSetting.FontSize,
         FontFamily = GlobalSetting.FontFamily,
-        MaxLines = 3,
         LineBreakMode = LineBreakMode.WordWrap
     };
     private bool _isDisabled;

--- a/src/InputKit.Maui/Shared/Controls/RadioButton.cs
+++ b/src/InputKit.Maui/Shared/Controls/RadioButton.cs
@@ -25,7 +25,8 @@ public class RadioButton : StatefulStackLayout
         Size = 25,
         CornerRadius = -1,
         FontSize = 14,
-        LabelPosition = LabelPosition.After
+        LabelPosition = LabelPosition.After,
+        LineBreakMode = LineBreakMode.WordWrap
     };
     #endregion
 
@@ -52,13 +53,13 @@ public class RadioButton : StatefulStackLayout
     };
     protected internal Label lblText = new Label
     {
+        LineBreakMode = GlobalSetting.LineBreakMode,
         VerticalTextAlignment = TextAlignment.Center,
         VerticalOptions = LayoutOptions.Center,
         HorizontalOptions = LayoutOptions.Start,
         TextColor = GlobalSetting.TextColor,
         FontSize = GlobalSetting.FontSize,
         FontFamily = GlobalSetting.FontFamily,
-        LineBreakMode = LineBreakMode.WordWrap
     };
     private bool _isDisabled;
     protected const double DOT_FULL_SCALE = .65;
@@ -214,6 +215,12 @@ public class RadioButton : StatefulStackLayout
         get => (LabelPosition)GetValue(LabelPositionProperty);
         set => SetValue(LabelPositionProperty, value);
     }
+
+    /// <summary>
+    /// Gets or sets the line break mode for the label.
+    /// </summary>
+    public LineBreakMode LineBreakMode { get => (LineBreakMode)GetValue(LineBreakModeProperty); set => SetValue(LineBreakModeProperty, value); }
+
     #endregion
 
     #region BindableProperties
@@ -235,6 +242,11 @@ public class RadioButton : StatefulStackLayout
         returnType: typeof(LabelPosition), defaultBindingMode: BindingMode.TwoWay,
         defaultValue: GlobalSetting.LabelPosition,
         propertyChanged: (bo, ov, nv) => (bo as RadioButton).ApplyLabelPosition((LabelPosition)nv));
+
+
+    public static readonly BindableProperty LineBreakModeProperty = BindableProperty.Create(nameof(LineBreakMode), typeof(LineBreakMode), typeof(RadioButton), defaultValue: GlobalSetting.LineBreakMode,
+        propertyChanged: ( bindable, oldValue, newValue ) => (bindable as RadioButton).lblText.LineBreakMode = (LineBreakMode)newValue);
+
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     #endregion
 

--- a/src/InputKit.Maui/Shared/Controls/RadioButton.cs
+++ b/src/InputKit.Maui/Shared/Controls/RadioButton.cs
@@ -54,12 +54,12 @@ public class RadioButton : StatefulStackLayout
     protected internal Label lblText = new Label
     {
         LineBreakMode = GlobalSetting.LineBreakMode,
-        VerticalTextAlignment = TextAlignment.Center,
         VerticalOptions = LayoutOptions.Center,
         HorizontalOptions = LayoutOptions.Start,
-        TextColor = GlobalSetting.TextColor,
         FontSize = GlobalSetting.FontSize,
+        TextColor = GlobalSetting.TextColor,
         FontFamily = GlobalSetting.FontFamily,
+        IsVisible = false
     };
     private bool _isDisabled;
     protected const double DOT_FULL_SCALE = .65;

--- a/src/InputKit.Maui/Shared/Controls/RadioButton.cs
+++ b/src/InputKit.Maui/Shared/Controls/RadioButton.cs
@@ -144,7 +144,7 @@ public class RadioButton : StatefulStackLayout
     /// <summary>
     /// Value to keep inside of Radio Button
     /// </summary>
-    public object Value { get; set; }
+    public object Value { get => GetValue(ValueProperty); set => SetValue(ValueProperty, value); }
 
     /// <summary>
     /// Gets or Sets, is that Radio Button selected/choosed/Checked
@@ -264,6 +264,7 @@ public class RadioButton : StatefulStackLayout
     public static readonly BindableProperty IconHorizontalOptionsProperty = BindableProperty.Create(nameof(IconHorizontalOptions), typeof(LayoutOptions), typeof(RadioButton), defaultValue: LayoutOptions.Center,
         propertyChanged: ( bindable, oldValue, newValue ) => (bindable as RadioButton).IconLayout.HorizontalOptions = (LayoutOptions)newValue);
 
+    public static readonly BindableProperty ValueProperty = BindableProperty.Create(nameof(Value), typeof(object), typeof(RadioButton), defaultBindingMode: BindingMode.OneTime);
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     #endregion
 

--- a/src/InputKit.Maui/Shared/Controls/RadioButton.cs
+++ b/src/InputKit.Maui/Shared/Controls/RadioButton.cs
@@ -257,6 +257,22 @@ public class RadioButton : StatefulStackLayout
         }
     }
 
+    protected override async void OnSizeAllocated(double width, double height)
+    {
+        base.OnSizeAllocated(width, height);
+
+        // TODO: Remove this logic after resolution of https://github.com/dotnet/maui/issues/8873
+        // This is a workaround.
+
+#if ANDROID
+        await Task.Delay(1);
+#endif
+        if (IconLayout.Width != -1 && lblText.Width > this.Width)
+        {
+            lblText.MaximumWidthRequest = this.Width - this.Spacing - IconLayout.Width;
+        }
+    }
+
     private protected virtual void UpdateShape()
     {
         iconChecked.Data = SelectedIconGeomerty;


### PR DESCRIPTION
This PR covers the proposals from https://github.com/enisn/Xamarin.Forms.InputKit/issues/348#issue-1664894369 with the exception of FontFamily. I noticed the property was there already and I don't see a need for databinding.

I turned the `Value` property of `RadioButton` into bindable to make something like the following possible

```
<input:RadioButtonGroupView BindableLayout.ItemsSource="{Binding Items}"
                            BindableLayout.ItemTemplate="{StaticResource ItemTemplate}"
                            SelectedItem="{Binding SelectedItem, Mode=TwoWay}"/>
```
