### PR TITLE
Fixed an incorrect selection handling by SelectionView

### DIFF
--- a/src/InputKit.Maui/Shared/Controls/SelectionView.cs
+++ b/src/InputKit.Maui/Shared/Controls/SelectionView.cs
@@ -282,7 +282,7 @@ public partial class SelectionView : Grid
     {
         if ((int)SelectionType % 2 == 0)
         {
-            if (sender is ISelection selection && selection.IsSelected)
+            if (sender is ISelection selection)
             {
                 if (selection.IsSelected)
                 {


### PR DESCRIPTION
When I was working on the previous PR I noticed there is a bug in selection view. An extra condition would cause duplicate items in the SelectedItems collection.