### PR TITLE
fix(RadioButton): fixed behaviour on fast tap

### DIFF
--- a/src/InputKit.Maui/Shared/Controls/RadioButton.cs
+++ b/src/InputKit.Maui/Shared/Controls/RadioButton.cs
@@ -313,13 +313,13 @@ public class RadioButton : StatefulStackLayout
         var isCheckedInLastState = iconChecked.Scale == DOT_FULL_SCALE;
 
         var changed = isCheckedInLastState != isChecked;
-
         if (changed)
         {
-            iconChecked.ScaleTo(isChecked ? DOT_FULL_SCALE : 0, 180);
-            UpdateColors();
             Checked?.Invoke(this, null);
         }
+
+        iconChecked.ScaleTo(isChecked ? DOT_FULL_SCALE : 0, 180);
+        UpdateColors();
 
         var state = isChecked ? VisualStateManager.CommonStates.Selected : VisualStateManager.CommonStates.Normal;
         VisualStateManager.GoToState(this, state);


### PR DESCRIPTION
Hi all,

I figured out that when tapping multiple radio options at once, all radio buttons become active. This is not an expected behaviour since radio buttons are meant to be selected separate. While debugging, I noticed that the ScaleTo and UpdateColors will not called if the IsChecked changes too fast. This PR will fix this.