### PR TITLE
Apply animations only if View is Loaded

### DIFF
--- a/src/InputKit.Maui/Shared/Controls/CheckBox.cs
+++ b/src/InputKit.Maui/Shared/Controls/CheckBox.cs
@@ -479,7 +479,14 @@ public partial class CheckBox : StatefulStackLayout, IValidatable
 
     public static void ApplyIsChecked(CheckBox checkBox, bool isChecked)
     {
-        checkBox.selectedIcon.ScaleTo(isChecked ? CHECK_SIZE_RATIO : 0, 160);
+        if (checkBox.IsLoaded)
+        {
+            checkBox.selectedIcon.ScaleTo(isChecked ? CHECK_SIZE_RATIO : 0, 160);
+        }
+        else
+        {
+            checkBox.selectedIcon.Scale = isChecked ? CHECK_SIZE_RATIO : 0;
+        }
 
         checkBox.UpdateColors();
 

--- a/src/InputKit.Maui/Shared/Controls/RadioButton.cs
+++ b/src/InputKit.Maui/Shared/Controls/RadioButton.cs
@@ -318,7 +318,15 @@ public class RadioButton : StatefulStackLayout
             Checked?.Invoke(this, null);
         }
 
-        iconChecked.ScaleTo(isChecked ? DOT_FULL_SCALE : 0, 180);
+        if (this.IsLoaded)
+        {
+            iconChecked.ScaleTo(isChecked ? DOT_FULL_SCALE : 0, 180);
+        }
+        else
+        {
+            iconChecked.Scale = isChecked ? DOT_FULL_SCALE : 0;
+        }
+
         UpdateColors();
 
         var state = isChecked ? VisualStateManager.CommonStates.Selected : VisualStateManager.CommonStates.Normal;


### PR DESCRIPTION
Resolves https://github.com/enisn/Xamarin.Forms.InputKit/issues/359
Closes https://github.com/enisn/UraniumUI/issues/705