### PR TITLE
Fixed "PlatformView cannot be null here" crash on WinUI

### DIFF
--- a/src/InputKit.Maui/Platforms/Windows/Handlers/StatefulGridHandler.Windows.cs
+++ b/src/InputKit.Maui/Platforms/Windows/Handlers/StatefulGridHandler.Windows.cs
@@ -12,20 +12,20 @@ namespace InputKit.Handlers
     {
         protected override void ConnectHandler(LayoutPanel platformView)
         {
-            PlatformView.PointerPressed += NativeView_PointerPressed;
-            PlatformView.PointerReleased += NativeView_PointerReleased;
-            PlatformView.PointerEntered += NativeView_PointerEntered;
-            PlatformView.PointerExited += NativeView_PointerExited;
+            platformView.PointerPressed += NativeView_PointerPressed;
+            platformView.PointerReleased += NativeView_PointerReleased;
+            platformView.PointerEntered += NativeView_PointerEntered;
+            platformView.PointerExited += NativeView_PointerExited;
         }
 
         protected override void DisconnectHandler(LayoutPanel platformView)
         {
-            PlatformView.PointerPressed -= NativeView_PointerPressed;
-            PlatformView.PointerReleased -= NativeView_PointerReleased;
-            PlatformView.PointerEntered -= NativeView_PointerEntered;
-            PlatformView.PointerExited -= NativeView_PointerExited;
+            platformView.PointerPressed -= NativeView_PointerPressed;
+            platformView.PointerReleased -= NativeView_PointerReleased;
+            platformView.PointerEntered -= NativeView_PointerEntered;
+            platformView.PointerExited -= NativeView_PointerExited;
         }
-
+            
         private void NativeView_PointerExited(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)
         {
             if (VirtualView is StatefulGrid stateful)

--- a/src/InputKit.Maui/Platforms/Windows/Handlers/StatefulStackLayoutHandler.Windows.cs
+++ b/src/InputKit.Maui/Platforms/Windows/Handlers/StatefulStackLayoutHandler.Windows.cs
@@ -9,18 +9,18 @@ namespace InputKit.Handlers
     {
         protected override void ConnectHandler(LayoutPanel platformView)
         {
-            PlatformView.PointerPressed += NativeView_PointerPressed;
-            PlatformView.PointerReleased += NativeView_PointerReleased;
-            PlatformView.PointerEntered += NativeView_PointerEntered;
-            PlatformView.PointerExited += NativeView_PointerExited;
+            platformView.PointerPressed += NativeView_PointerPressed;
+            platformView.PointerReleased += NativeView_PointerReleased;
+            platformView.PointerEntered += NativeView_PointerEntered;
+            platformView.PointerExited += NativeView_PointerExited;
         }
 
         protected override void DisconnectHandler(LayoutPanel platformView)
         {
-            PlatformView.PointerPressed -= NativeView_PointerPressed;
-            PlatformView.PointerReleased -= NativeView_PointerReleased;
-            PlatformView.PointerEntered -= NativeView_PointerEntered;
-            PlatformView.PointerExited -= NativeView_PointerExited;
+            platformView.PointerPressed -= NativeView_PointerPressed;
+            platformView.PointerReleased -= NativeView_PointerReleased;
+            platformView.PointerEntered -= NativeView_PointerEntered;
+            platformView.PointerExited -= NativeView_PointerExited;
         }
 
         private void NativeView_PointerExited(object sender, Microsoft.UI.Xaml.Input.PointerRoutedEventArgs e)


### PR DESCRIPTION
Changed windows platform handlers to use the passed platformView parameter for registering / deregistering handlers.

The derived PlatformView property that was used before is null at the time DisconnectHandler is called, and was causing an app crash "PlatformView cannot be null here" when using a RadioButton on Windows.