### PR TITLE
Fixed potential memory leak in Android StatefulGridHandler

### DIFF
--- a/src/InputKit.Maui/Platforms/Android/Handlers/StatefulGridHandler.Android.cs
+++ b/src/InputKit.Maui/Platforms/Android/Handlers/StatefulGridHandler.Android.cs
@@ -11,11 +11,21 @@ namespace InputKit.Handlers
     {
         protected override LayoutViewGroup CreatePlatformView()
         {
-            var nativeView = base.CreatePlatformView();
+            return base.CreatePlatformView();
+        }
 
-            nativeView.Touch += NativeView_Touch;
+        protected override void ConnectHandler(LayoutPanel platformView)
+        {
+            base.ConnectHandler(platformView);
+            
+            platformView.Touch += NativeView_Touch;
+        }
 
-            return nativeView;
+        protected override void DisconnectHandler(LayoutPanel platformView)
+        {
+            platformView.Touch -= NativeView_Touch;
+            
+            base.DisconnectHandler(platformView);
         }
 
         private void NativeView_Touch(object sender, View.TouchEventArgs e)


### PR DESCRIPTION
This has to be handled similar to the Windows handler: https://github.com/enisn/Xamarin.Forms.InputKit/blob/develop/src/InputKit.Maui/Platforms/Windows/Handlers/StatefulGridHandler.Windows.cs