### PR TITLE
Fixed memory leak in Android StatefulStackLayoutHandler (i.e. RadioButton)

### DIFF
--- a/src/InputKit.Maui/Platforms/Android/Handlers/StatefulStackLayoutHandler.Android.cs
+++ b/src/InputKit.Maui/Platforms/Android/Handlers/StatefulStackLayoutHandler.Android.cs
@@ -10,13 +10,23 @@ namespace InputKit.Handlers
     {
         protected override LayoutViewGroup CreatePlatformView()
         {
-            var nativeView = base.CreatePlatformView();
-
-            nativeView.Touch += NativeView_Touch;
-
-            return nativeView;
+            return nativeView = base.CreatePlatformView();
         }
 
+        protected override void ConnectHandler(LayoutPanel platformView)
+        {
+            base.ConnectHandler(platformView);
+
+            platformView.Touch += NativeView_Touch;
+        }
+
+        protected override void DisconnectHandler(LayoutPanel platformView)
+        {
+            platformView.Touch -= NativeView_Touch;
+
+            base.DisconnectHandler(platformView);
+        }
+        
         private void NativeView_Touch(object sender, View.TouchEventArgs e)
         {
             if (VirtualView is StatefulStackLayout stateful)


### PR DESCRIPTION
This has to be handled similar to the Windows handler: https://github.com/enisn/Xamarin.Forms.InputKit/blob/develop/src/InputKit.Maui/Platforms/Windows/Handlers/StatefulGridHandler.Windows.cs